### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/grandegiraffo/bingobanko/security/code-scanning/1](https://github.com/grandegiraffo/bingobanko/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow to restrict GitHub token permissions according to the principle of least privilege. In this case, since the workflow only performs build, lint, and test operations and does not write to the repo (e.g., no release, no status updates, no pull request comments), the minimal permission needed is `contents: read`. This reduces the risk of malicious code gaining write access to the repository if the workflow is ever compromised.

The best way is to add the following block at the root of the workflow, directly below the `name:` field (and above the `on:` block). This will apply to all jobs in the workflow. Only .github/workflows/build.yml needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
